### PR TITLE
Add coffee-loader dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/4ver/gif-stop",
   "devDependencies": {
     "chai": "~1.9.1",
+    "coffee-loader": "^0.7.2",
     "coffee-script": "~1.7.1",
     "gulp": ">=3.8.2",
     "gulp-coffee": "2.0.1",


### PR DESCRIPTION
Getting `missing module "coffee-loader"` when running gulp.